### PR TITLE
Rescue `ActiveRecord::NoDatabaseError` during initialization

### DIFF
--- a/lib/active_record/postgres/constraints/railtie.rb
+++ b/lib/active_record/postgres/constraints/railtie.rb
@@ -6,23 +6,29 @@ module ActiveRecord
         initializer 'active_record.postgres.constraints.patch_active_record' do
           ActiveSupport.on_load(:active_record) do
             AR_CAS = ::ActiveRecord::ConnectionAdapters
+            begin
+              connection = ActiveRecord::Base.connection
+              using_pg = connection.class.to_s == "#{AR_CAS}::PostgreSQLAdapter"
+              if using_pg
+                Rails.logger.info do
+                  'Applying Postgres Constraints patches to ActiveRecord'
+                end
+                AR_CAS::TableDefinition.include TableDefinition
+                AR_CAS::PostgreSQLAdapter.include PostgreSQLAdapter
+                AR_CAS::AbstractAdapter::SchemaCreation.prepend SchemaCreation
 
-            connection = ActiveRecord::Base.connection
-            using_pg = connection.class.to_s == "#{AR_CAS}::PostgreSQLAdapter"
-            if using_pg
-              Rails.logger.info do
-                'Applying Postgres Constraints patches to ActiveRecord'
+                ::ActiveRecord::Migration::CommandRecorder.include CommandRecorder
+                ::ActiveRecord::SchemaDumper.prepend SchemaDumper
+              else
+                Rails.logger.warn do
+                  'Not applying Postgres Constraints patches to ActiveRecord ' \
+                'since the database is not postgres'
+                end
               end
-              AR_CAS::TableDefinition.include TableDefinition
-              AR_CAS::PostgreSQLAdapter.include PostgreSQLAdapter
-              AR_CAS::AbstractAdapter::SchemaCreation.prepend SchemaCreation
-
-              ::ActiveRecord::Migration::CommandRecorder.include CommandRecorder
-              ::ActiveRecord::SchemaDumper.prepend SchemaDumper
-            else
+            rescue ActiveRecord::NoDatabaseError
               Rails.logger.warn do
                 'Not applying Postgres Constraints patches to ActiveRecord ' \
-                  'since the database is not postgres'
+                'because the database does not exist'
               end
             end
           end


### PR DESCRIPTION
Rescue the `ActiveRecord::NoDatabaseError` so you can still create databases with rake tasks in Rails 5.2. See issue #2 for more details. Essentially, something changed in Rails or Railties in version 5.2 such that `connection = ActiveRecord::Base.connection` now throws an exception when running `db:create` rake tasks. 