### PR TITLE
Add Rails 4.2 support

### DIFF
--- a/active_record-postgres-constraints.gemspec
+++ b/active_record-postgres-constraints.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
     '{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.md'
   ]
 
-  s.add_dependency 'rails', '~> 5.0'
+  s.add_dependency 'rails', '>= 4.2'
   s.add_dependency 'pg'
 
   s.add_development_dependency 'rubocop'

--- a/lib/active_record/postgres/constraints/schema_dumper.rb
+++ b/lib/active_record/postgres/constraints/schema_dumper.rb
@@ -3,17 +3,41 @@ module ActiveRecord
   module Postgres
     module Constraints
       module SchemaDumper
-        def indexes_in_create(table, stream)
-          super
-          constraints = @connection.constraints(table)
-          return unless constraints.any?
-          constraint_statements = constraints.map do |constraint|
-            name = constraint['conname']
-            conditions = constraint['consrc']
-            "    t.check_constraint :#{name}, #{conditions.inspect}"
+
+        if ActiveRecord::SchemaDumper.private_instance_methods(false).include?(:indexes_in_create)
+          # Rails >= 5.0
+          def indexes_in_create(table, stream)
+            super
+            constraints = @connection.constraints(table)
+            return unless constraints.any?
+            constraint_statements = constraints.map do |constraint|
+              name = constraint['conname']
+              conditions = constraint['consrc']
+              "    t.check_constraint :#{name}, #{conditions.inspect}"
+            end
+            stream.puts constraint_statements.sort.join("\n")
           end
-          stream.puts constraint_statements.sort.join("\n")
+        else
+          # Rails < 5.0 does not have hook for table creation so add separate statements
+          def indexes(table, stream)
+            super
+            constraints = @connection.constraints(table)
+            return unless constraints.any?
+            constraint_statements = constraints.map do |constraint|
+              name = constraint['conname']
+              conditions = constraint['consrc']
+              statement_parts = [
+                  "add_check_constraint #{remove_prefix_and_suffix(table).inspect}",
+                  "#{name.inspect}",
+                  "#{conditions.inspect}"
+              ]
+              "  #{statement_parts.join(', ')}"
+            end
+            stream.puts constraint_statements.sort.join("\n")
+            stream.puts
+          end
         end
+
       end
     end
   end


### PR DESCRIPTION
This is by no means a finished pull request, but is intended to demonstrate the relative ease with which  Rails 4.2 compatibility (and possibly further back) can be added.

Further work needed:
- [ ] Add tests or extend existing test config to cover Rails 4.2
- [ ] Possibly refactor the code for supporting older versions somewhere else

Before doing this, I want to sanity check whether this is something you'd want for this project. I can understand why, from a forward-thinking perspective, you might not want to add Rails 4.2 to the list of tested and supported targets for this gem.

Let me know what you think about this and we can go from there