### PR TITLE
Remove consrc for PostgreSQL 12 compat

### DIFF
--- a/lib/active_record/postgres/constraints/postgresql_adapter.rb
+++ b/lib/active_record/postgres/constraints/postgresql_adapter.rb
@@ -28,7 +28,7 @@ module ActiveRecord
 
         def constraints(table)
           types = CONSTRAINT_TYPES.values.map { |v| "'#{v}'" }.join(', ')
-          sql = "SELECT conname, consrc, contype,
+          sql = "SELECT conname, contype,
             pg_get_constraintdef(pg_constraint.oid) AS definition
             FROM pg_constraint
             JOIN pg_class ON pg_constraint.conrelid = pg_class.oid

--- a/lib/active_record/postgres/constraints/types/check.rb
+++ b/lib/active_record/postgres/constraints/types/check.rb
@@ -14,7 +14,7 @@ module ActiveRecord
 
             def to_schema_dump(constraint)
               name = constraint['conname']
-              conditions = constraint['consrc']
+              conditions = constraint['definition'].gsub(/^CHECK\s*\((.*)\)\s*$/, '\\1')
               "    t.check_constraint :#{name}, #{conditions.inspect}"
             end
 


### PR DESCRIPTION
Removes `consrc` for check constraints by transforming the result of `pg_get_constraintdef`. All tests passing against PostgreSQL 12.1. 